### PR TITLE
Multiple Fixes: Error on edit transfer, select expenses drawer, wrong signed on status

### DIFF
--- a/src/components/UI/Account/features/SelectAccountDialog/SelectAccountDialog.tsx
+++ b/src/components/UI/Account/features/SelectAccountDialog/SelectAccountDialog.tsx
@@ -8,20 +8,24 @@ import { useAppDispatch, useAppSelector } from '../../../../../redux/hooks';
 import { updateSelectedAccount, updateAccounts } from '../../../../../redux/slices/Accounts/accounts.slice';
 import { ListAccountSelected, ListItemButtonContainer } from './SelectAccountDialog.styled';
 import { DialogTitle, ListItemText } from '../../../../../styles';
+import { useGuestUser } from '../../../../../hooks';
 
 const SelectAccountDialog = ({
   open, onClose,
 }: AccountDialogProps) => {
   const dispatch = useAppDispatch();
+  const { isGuestUser, loadRecords } = useGuestUser();
   const accountsReduxState = useAppSelector((state) => state.accounts);
+  const recordsLocalStorage = useAppSelector((state) => state.records.recordsLocalStorage);
   const accountsUI = accountsReduxState?.accounts;
 
   const handleAccountClick = (accountId: string) => {
     if (accountsUI) {
       const newAccounts: AccountUI[] = (accountsUI).map((account) => {
         if (account._id === accountId) {
-          const newSelectedAccount = { ...account, selected: true };
+          const newSelectedAccount: AccountUI = { ...account, selected: true };
           dispatch(updateSelectedAccount(newSelectedAccount));
+          if (isGuestUser) loadRecords(newSelectedAccount, recordsLocalStorage ?? []);
           return newSelectedAccount;
         }
 

--- a/src/components/UI/Records/features/Features.styled.ts
+++ b/src/components/UI/Records/features/Features.styled.ts
@@ -40,18 +40,22 @@ export const LoadingExpensesContainer = styled.div`
   padding-top: 3rem;
 
   @media ${responsiveBreakpoints.tablet} {
-    min-width: 48rem;
+    min-width: 68.4rem;
   }
 
   @media ${responsiveBreakpoints.desktop} {
-    min-width: 70rem;
+    min-width: 77rem;
   }
 `;
 
 export const ExpensesNotFoundContainer = styled.div`
   padding-top: 3rem;
 
-  @media ${responsiveBreakpoints.tabletAndDesktop} {
+  @media ${responsiveBreakpoints.tablet} {
+    min-width: 68.4rem;
+  }
+
+  @media ${responsiveBreakpoints.desktop} {
     min-width: 77rem;
   }
 `;

--- a/src/components/UI/Records/features/Transfer/Transfer.tsx
+++ b/src/components/UI/Records/features/Transfer/Transfer.tsx
@@ -14,7 +14,7 @@ import { TypeOfRecord, ExpensePaid } from '../../../../../globalInterface';
 import { TransferSchema } from '../../../../../validationsSchemas/records.schema';
 import { scrollToTop } from '../../../../../utils/ScrollToTop';
 import { getOriginAccount, getValuesIncomeAndExpense } from './Transfer.util';
-import { resetLocalStorageWithUserOnly, symmetricDifferenceExpensesRelated } from '../../../../../utils';
+import { formatCurrencyToString, resetLocalStorageWithUserOnly, symmetricDifferenceExpensesRelated } from '../../../../../utils';
 
 import { TransferAccountSelector } from '../TransferAccountSelector';
 import { TransactionFormFields } from '../TransactionFormFields';
@@ -148,7 +148,8 @@ const Transfer = ({ action, typeOfRecord, edit = false }: TransferProps) => {
     if (recordToBeEdited?.amount !== Number(initialAmount.current)) {
       amountTouched = true;
     }
-    const newAmount = verifyAmountEndsPeriod(initialAmount.current);
+    const amountFormatted = formatCurrencyToString(values.amount);
+    const newAmount = verifyAmountEndsPeriod(initialAmount.current || amountFormatted);
     const { amount, ...restValues } = values;
     const newValues = { ...restValues, amount: newAmount };
     const { newValuesIncome, newValuesExpense } = getValuesIncomeAndExpense({ values: newValues, expensesSelected });

--- a/src/components/templates/Header/Header.tsx
+++ b/src/components/templates/Header/Header.tsx
@@ -58,9 +58,9 @@ const Header = ({ isLandingPage = false }: HeaderProps) => {
               </AnchorButton>
             </FlexContainer>
           ) }
-          { (!isGuestUser && isMobile && !userLoggedOn) && (
+          { (isMobile && !userLoggedOn) && (
             <IconButton onClick={toggleHamburguerDrawer}>
-              <AppIcon icon="HamburguerMenu" />
+              <AppIcon icon="HamburguerMenu" fillColor={isLandingPage ? AppColors.white : AppColors.primary} />
             </IconButton>
           )}
         </HeaderContainer>

--- a/src/hooks/useAllExpenses/useAllExpenses.tsx
+++ b/src/hooks/useAllExpenses/useAllExpenses.tsx
@@ -21,9 +21,8 @@ const useAllExpenses = ({ month, year, accountId }: UseAllExpensesProps) => {
   const [localRecords, setLocalRecords] = useState<Expense[]>([]);
   const [noExpensesFound, setNoExpensesFound] = useState<boolean>(false);
 
-  const toggleNoExpensesFound = () => {
-    setNoExpensesFound((prevState) => !prevState);
-  };
+  const turnOnNoExpensesFound = () => setNoExpensesFound(true);
+  const turnOffNoExpensesFound = () => setNoExpensesFound(false);
 
   useEffect(() => {
     if (isGuestUser && recordsLocalStorage) {
@@ -33,7 +32,8 @@ const useAllExpenses = ({ month, year, accountId }: UseAllExpensesProps) => {
         currentMonth,
         year,
         recordsLocalStorageSelectedAccount,
-        toggleNoExpensesFound,
+        turnOnNoExpensesFound,
+        turnOffNoExpensesFound,
         noExpensesFound,
       });
       setLocalRecords(fetchedLocalRecords);
@@ -47,9 +47,12 @@ const useAllExpenses = ({ month, year, accountId }: UseAllExpensesProps) => {
 
   useEffect(() => {
     if (currentData?.message === 'No expenses found.') {
-      toggleNoExpensesFound();
+      turnOnNoExpensesFound();
     }
-  }, [currentData?.message]);
+    if (!currentData?.message) {
+      turnOffNoExpensesFound();
+    }
+  }, [currentData]);
 
   const onlyExpensesIncomes = useMemo(
     () => (currentData?.records ?? []).filter((record) => record.typeOfRecord === 'expense'),

--- a/src/hooks/useAllExpenses/utils.ts
+++ b/src/hooks/useAllExpenses/utils.ts
@@ -8,15 +8,16 @@ interface GetLocalRecordsProps {
   currentMonth: AbbreviatedMonthsType;
   year: string;
   recordsLocalStorageSelectedAccount: RecordsLocalStorage | undefined;
-  toggleNoExpensesFound: () => void;
+  turnOnNoExpensesFound: () => void;
+  turnOffNoExpensesFound: () => void;
   noExpensesFound: boolean;
 }
 
 export const getLocalRecords = ({
-  month, lastMonth, currentMonth, year, recordsLocalStorageSelectedAccount, toggleNoExpensesFound, noExpensesFound,
+  month, lastMonth, currentMonth, year, recordsLocalStorageSelectedAccount, turnOnNoExpensesFound, turnOffNoExpensesFound, noExpensesFound,
 }: GetLocalRecordsProps) => {
   if (noExpensesFound) {
-    toggleNoExpensesFound();
+    turnOffNoExpensesFound();
   }
 
   const recordAge = getAgeLocalRecord({ month, lastMonth, currentMonth });
@@ -36,7 +37,7 @@ export const getLocalRecords = ({
       (record) => record.date.getMonth() === new Date(`${year}-${month}-01`).getMonth(),
     );
     if (recordsFormattedOlderRecords.length === 0) {
-      toggleNoExpensesFound();
+      turnOnNoExpensesFound();
     }
     return recordsFormattedOlderRecords;
   }

--- a/src/hooks/useAllExpenses/utils.ts
+++ b/src/hooks/useAllExpenses/utils.ts
@@ -41,5 +41,7 @@ export const getLocalRecords = ({
     }
     return recordsFormattedOlderRecords;
   }
+
+  if (recordsFormatted.length === 0) turnOnNoExpensesFound();
   return recordsFormatted;
 };

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -5,7 +5,7 @@ import { LoginValues } from '../pages/LoginModule/Login/interface';
 import { SystemStateEnum } from '../enums';
 import { useNotification } from './useNotification';
 import { addToLocalStorage, saveInfoToLocalStorage } from '../utils';
-import { useAppDispatch } from '../redux/hooks';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
 import {
   signOff, signOn,
 } from '../redux/slices/User/user.slice';
@@ -47,6 +47,7 @@ const useLogin = () => {
   } = useNotification({
     title: NOTIFICATION_TITLE, description: NOTIFICATION_DESCRIPTION, status: NOTIFICATION_STATUS,
   });
+  const hasSignedOn = useAppSelector((state) => state.userInterface.hasSignedOn);
 
   const resetUserGuestLocalStorage = () => {
     dispatch(resetRecordsLocalStorage());
@@ -62,7 +63,7 @@ const useLogin = () => {
     dispatch(resetAccounts());
     dispatch(resetSelectedAccount());
     dispatch(resetTotalBalanceRecords());
-    dispatch(toggleSignedOn());
+    if (hasSignedOn) dispatch(toggleSignedOn());
     saveInfoToLocalStorage({});
     resetLoginIn();
     navigate(LANDING_ROUTE);
@@ -76,7 +77,7 @@ const useLogin = () => {
       const user = await loginMutation({ values }).unwrap();
       // Save user on redux state of userInfo
       dispatch(signOn(user));
-      dispatch(toggleSignedOn());
+      if (!hasSignedOn) dispatch(toggleSignedOn());
       // Reset all information of the guest user in redux
       resetUserGuestLocalStorage();
       addToLocalStorage({ newInfo: user });

--- a/src/pages/LoginModule/Login/Login.tsx
+++ b/src/pages/LoginModule/Login/Login.tsx
@@ -3,11 +3,11 @@ import {
   Formik, Form, Field,
 } from 'formik';
 import { useEffect, useState } from 'react';
-
 import { useLocation } from 'react-router-dom';
+
 import { REGISTER_ROUTE } from '../../RoutesConstants';
-import { useLogin } from '../../../hooks/useLogin';
-import { useSyncLoginInfo } from '../../../hooks/useSyncLoginInfo';
+import { useAppSelector } from '../../../redux/hooks';
+import { useGuestUser, useSyncLoginInfo, useLogin } from '../../../hooks';
 import { LoginSchema } from '../../../validationsSchemas';
 import { Notification } from '../../../components/UI';
 import { TogglePasswordAdornment } from '../../../components/UI/TogglePasswordAdornment';
@@ -16,11 +16,11 @@ import {
   Main, LoginCard, LogoContainer,
   FormLoginTitle, FormInstructions, LoginInput, ForgotPasswordLink,
 } from './Login.styled';
-import { useAppSelector } from '../../../redux/hooks';
 
 const Login = () => {
   const location = useLocation();
   const { navigateToDashboard } = useSyncLoginInfo();
+  const { isGuestUser } = useGuestUser();
   const {
     handleSubmit, handleShowNotification, notificationInfo, notification, submitOnPressEnter, loginSuccess, loginLoading,
   } = useLogin();
@@ -30,7 +30,7 @@ const Login = () => {
   const locationState = { prevPath: location.pathname };
 
   useEffect(() => {
-    if (hasSignedOn) {
+    if (hasSignedOn && !isGuestUser) {
       navigateToDashboard();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# PR Description
Changes:
- Fix on edit transfer, having error from backend having amount 0 of the records even if it was not modified.
*Prop amount when edited the transfer was empty because it took the initialAmount.current and it was empty as it was not edited the amount*

- Fix: On mobile, if the user is guest user and it's on mobile view, it won't have a menu to navigate to log in.
*Add hamburguer menu if mobile*

- Not reflecting changes when user is mobile, guest user and changes to other account
- When user wants to add an expense, selects a month that does not have records, it shows the message of no expenses found, then he selects other month with no records and the message disappears
- Having wrong signed on status
- Making the user to not letting him log in if he has the wrong signed status