### PR TITLE
Multiple fixes

### DIFF
--- a/src/hooks/useRecords/useRecords.tsx
+++ b/src/hooks/useRecords/useRecords.tsx
@@ -1095,14 +1095,21 @@ const useRecords = ({
   };
 
   const editIncome = async ({
-    values, recordId, previousAmount,
+    values, recordId, previousAmount, amountTouched,
   }: EditIncomeProps) => {
     try {
-      const { amount, date: dateValue } = values;
+      const { amount, date: dateValue, account: accountId } = values;
       const date = dateValue.toDate();
       const newValues: EditIncomeValues = { ...values, recordId };
 
       await editIncomeMutation({ values: newValues, bearerToken }).unwrap();
+
+      if (amountTouched) {
+        // Update only the redux state
+        updateAmountAccountOnEditRecord({
+          amount, isExpense: false, previousAmount, accountId,
+        });
+      }
       updateTotalsIncome({
         date, amount, edit: true, previousAmount,
       });

--- a/src/hooks/useRecords/useRecords.tsx
+++ b/src/hooks/useRecords/useRecords.tsx
@@ -1074,10 +1074,12 @@ const useRecords = ({
 
   const createIncome = async (values: CreateIncomeValuesApiRequest) => {
     try {
-      const { amount, date: dateValue } = values;
+      const { amount, date: dateValue, account: accountId } = values;
       const date = dateValue.toDate();
 
       await createIncomeMutation({ values, bearerToken }).unwrap();
+      // Update account in redux state, not in the backend
+      updateAmountAccount({ amount, isExpense: false, accountId });
       updateTotalsIncome({ date, amount });
 
       // Navigate to dashboard
@@ -1175,7 +1177,7 @@ const useRecords = ({
       }
 
       // Update Amount of the account.
-      const updateAmount = await updateAmountAccount({
+      const updateAmount = updateAmountAccount({
         amount: amountOfRecord, isExpense: deleteRecordExpense ?? false, deleteRecord: true, accountId: accountRecord, isGuestUser,
       });
       // If there's an error while updating the account, return

--- a/src/hooks/useRecords/useRecords.tsx
+++ b/src/hooks/useRecords/useRecords.tsx
@@ -964,10 +964,12 @@ const useRecords = ({
 
   const createExpense = async (values: CreateExpenseValuesApiRequest) => {
     try {
-      const { amount, date: dateValue } = values;
+      const { amount, date: dateValue, account: accountId } = values;
       const date = dateValue.toDate();
 
       await createExpenseMutation({ values, bearerToken }).unwrap();
+      // Update account in redux state, not in the backend
+      updateAmountAccount({ amount, isExpense: true, accountId });
       updateTotalsExpense({ date, amount });
 
       // Navigate to dashboard
@@ -1020,6 +1022,7 @@ const useRecords = ({
       const { amount: amountIncome, date: dateIncome } = valuesIncome;
 
       await createTransferMutation({ values: { expense: valuesExpense, income: valuesIncome }, bearerToken }).unwrap();
+      // Update account in redux state, not in the backend
       updateAmountAccount({ amount: amountExpense, isExpense: true, accountId: valuesExpense.account });
       updateAmountAccount({ amount: amountIncome, isExpense: false, accountId: valuesIncome.account });
       updateTotalsExpense({ date: dateExpense.toDate(), amount: amountExpense });

--- a/src/hooks/useRecords/useRecords.tsx
+++ b/src/hooks/useRecords/useRecords.tsx
@@ -1020,7 +1020,8 @@ const useRecords = ({
       const { amount: amountIncome, date: dateIncome } = valuesIncome;
 
       await createTransferMutation({ values: { expense: valuesExpense, income: valuesIncome }, bearerToken }).unwrap();
-
+      updateAmountAccount({ amount: amountExpense, isExpense: true, accountId: valuesExpense.account });
+      updateAmountAccount({ amount: amountIncome, isExpense: false, accountId: valuesIncome.account });
       updateTotalsExpense({ date: dateExpense.toDate(), amount: amountExpense });
       updateTotalsIncome({ date: dateIncome.toDate(), amount: amountIncome });
 

--- a/src/redux/slices/Records/actions/expenses.api.ts
+++ b/src/redux/slices/Records/actions/expenses.api.ts
@@ -2,7 +2,6 @@ import { DELETE_METHOD, POST_METHOD, PUT_METHOD } from '../../../../constants';
 import { budgetMasterApi } from '../../../budgetMaster.api';
 import {
   RECORD_TAG, EXPENSE_ROUTE, EXPENSE_TAG,
-  ACCOUNT_TAG,
 } from '../../../constants';
 import { CreateExpenseMutationProps, DeleteExpenseMutationProps, GetExpensesResponse } from '../interface';
 
@@ -33,7 +32,7 @@ export const expensesApiSlice = budgetMasterApi.injectEndpoints({
           Authorization: bearerToken,
         },
       }),
-      invalidatesTags: [RECORD_TAG, EXPENSE_TAG, ACCOUNT_TAG],
+      invalidatesTags: [RECORD_TAG, EXPENSE_TAG],
     }),
 
     editExpense: builder.mutation({
@@ -45,7 +44,7 @@ export const expensesApiSlice = budgetMasterApi.injectEndpoints({
           Authorization: bearerToken,
         },
       }),
-      invalidatesTags: [RECORD_TAG, EXPENSE_TAG, ACCOUNT_TAG],
+      invalidatesTags: [RECORD_TAG, EXPENSE_TAG],
     }),
 
     deleteExpense: builder.mutation({
@@ -57,7 +56,7 @@ export const expensesApiSlice = budgetMasterApi.injectEndpoints({
           Authorization: bearerToken,
         },
       }),
-      invalidatesTags: [RECORD_TAG, EXPENSE_TAG, ACCOUNT_TAG],
+      invalidatesTags: [RECORD_TAG, EXPENSE_TAG],
     }),
   }),
 });

--- a/src/redux/slices/Records/actions/incomes.api.ts
+++ b/src/redux/slices/Records/actions/incomes.api.ts
@@ -1,6 +1,6 @@
 import { POST_METHOD, PUT_METHOD } from '../../../../constants';
 import { budgetMasterApi } from '../../../budgetMaster.api';
-import { RECORD_TAG, INCOME_ROUTE, ACCOUNT_TAG } from '../../../constants';
+import { RECORD_TAG, INCOME_ROUTE } from '../../../constants';
 
 export const incomesApiSlice = budgetMasterApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -13,7 +13,7 @@ export const incomesApiSlice = budgetMasterApi.injectEndpoints({
           Authorization: bearerToken,
         },
       }),
-      invalidatesTags: [RECORD_TAG, ACCOUNT_TAG],
+      invalidatesTags: [RECORD_TAG],
     }),
 
     editIncome: builder.mutation({
@@ -25,7 +25,7 @@ export const incomesApiSlice = budgetMasterApi.injectEndpoints({
           Authorization: bearerToken,
         },
       }),
-      invalidatesTags: [RECORD_TAG, ACCOUNT_TAG],
+      invalidatesTags: [RECORD_TAG],
     }),
   }),
 });


### PR DESCRIPTION
Changes
- Update account on the redux state when create transfer rather than fetching again accounts.
- On create expense, update account redux state
- Validate that on edit, delete expense, only update account redux state
- Validate that on edit, delete, create income, only update account redux state
- Validate that on edit, delete, create transfer, only update account redux state