### PR TITLE
Fixes on currency input for decimals starting with 0 and strange characters

### DIFF
--- a/src/components/Other/CurrencyField/CurrencyField.tsx
+++ b/src/components/Other/CurrencyField/CurrencyField.tsx
@@ -25,6 +25,7 @@ const CurrencyField = ({
       component={InputForm}
       name={fieldName ?? 'amount'}
       type="text"
+      inputMode="numeric"
       variant="standard"
       label={labelName ?? 'Amount'}
       onChange={handleChange}

--- a/src/components/Other/CurrencyField/useHandleCurrencyField.tsx
+++ b/src/components/Other/CurrencyField/useHandleCurrencyField.tsx
@@ -55,6 +55,7 @@ const useHandleCurrencyField = ({
     } = validateCurrencyField(newValue);
     const [integers, decimals] = newValue.split('.');
     const hasDecimals = !!decimals;
+    const hasMoreThanThreeDecimals = hasDecimals && decimals.length > 2;
 
     if (emptyValue) {
       updateAmount('0');
@@ -70,6 +71,13 @@ const useHandleCurrencyField = ({
       updateAmount(newAmountNotFormatted);
       const newAmount = formatValueToCurrency({ amount: newAmountNotFormatted, hasNoDecimals: true, hasNoCurrencySign: true });
       setFieldValue(currentFieldName, newAmount);
+      return;
+    }
+
+    if (hasMoreThanThreeDecimals) {
+      const newDecimals = decimals.slice(0, 2);
+      const newValueFormatted = `${integers}.${newDecimals}`;
+      setFieldValue(currentFieldName, newValueFormatted);
       return;
     }
 

--- a/src/components/Other/CurrencyField/useHandleCurrencyField.tsx
+++ b/src/components/Other/CurrencyField/useHandleCurrencyField.tsx
@@ -16,7 +16,7 @@ const useHandleCurrencyField = ({
   const currentFieldName = fieldName ?? CURRENCY_FIELD_NAME;
 
   const validateCurrencyField = (value: string) => {
-    const hasNumericPeriodCommaRegex = /[0-9.,]+/;
+    const hasNumericPeriodCommaRegex = /^[0-9.,]+$/;
     const startsWithPeriodRegex = /^\./;
     const deletedNumberRegex = /,\d{2}$/;
     const EndsWithPeriodRegex = /[0-9]+[.]$/;
@@ -47,18 +47,21 @@ const useHandleCurrencyField = ({
     const newValue = event.target.value;
     const {
       valueHasForbiddenCharacters,
-      valueBeginsWithPeriod,
       emptyValue,
-      valueEndsWithPeriod,
       hasDeleted,
-      isValueThousandWithNoComma,
+      valueBeginsWithPeriod,
       isValueThousandWithComma,
+      valueEndsWithPeriod,
     } = validateCurrencyField(newValue);
+    const [integers, decimals] = newValue.split('.');
+    const hasDecimals = !!decimals;
+
     if (emptyValue) {
       updateAmount('0');
       setFieldValue(currentFieldName, '');
       return;
     }
+
     if (valueHasForbiddenCharacters) return;
     if (valueBeginsWithPeriod) return;
 
@@ -70,30 +73,27 @@ const useHandleCurrencyField = ({
       return;
     }
 
-    if (isValueThousandWithNoComma) {
-      if (valueEndsWithPeriod) {
-        setFieldValue(currentFieldName, newValue);
-        return;
-      }
-      updateAmount(newValue);
-      const newAmount = formatValueToCurrency({ amount: newValue, hasNoDecimals: true, hasNoCurrencySign: true });
-      setFieldValue(currentFieldName, newAmount);
-      return;
-    }
-
     if (isValueThousandWithComma) {
       if (valueEndsWithPeriod) {
         setFieldValue(currentFieldName, newValue);
         return;
       }
       const newAmountNotFormatted = formatCurrencyToString(newValue);
+      const valueFormatted = formatValueToCurrency({ amount: newAmountNotFormatted, hasNoDecimals: true, hasNoCurrencySign: true });
+      const completeValueFormatted = hasDecimals ? `${valueFormatted}.${decimals}` : valueFormatted;
       updateAmount(newAmountNotFormatted);
-      const newAmount = formatValueToCurrency({ amount: newAmountNotFormatted, hasNoDecimals: true, hasNoCurrencySign: true });
-      setFieldValue(currentFieldName, newAmount);
+      setFieldValue(currentFieldName, completeValueFormatted);
+      return;
+    }
+
+    if (valueEndsWithPeriod) {
+      setFieldValue(currentFieldName, newValue);
       return;
     }
     updateAmount(newValue);
-    setFieldValue(currentFieldName, newValue);
+    const valueFormatted = formatValueToCurrency({ amount: integers, hasNoDecimals: true, hasNoCurrencySign: true });
+    const completeValueFormatted = hasDecimals ? `${valueFormatted}.${decimals}` : valueFormatted;
+    setFieldValue(currentFieldName, completeValueFormatted);
   };
 
   return {

--- a/src/utils/FormatNumberToCurrency/index.ts
+++ b/src/utils/FormatNumberToCurrency/index.ts
@@ -7,12 +7,6 @@ const usDollar = Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
 });
 
-const usDollarWithoutDecimals = Intl.NumberFormat('en-US', {
-  style: CURRENCY,
-  currency: USD_CURRENCY,
-  minimumFractionDigits: 0,
-});
-
 /*
 * This function formats a number to usd or mexican currency.
 * The props are:
@@ -33,11 +27,12 @@ export const formatValueToCurrency = ({
   const transformedAmount = typeof amount === 'number' ? amount : Number(amount);
   const amountCurrency = usDollar.format(transformedAmount);
   if (hasNoDecimals) {
-    const currencyWithoutDecimals = usDollarWithoutDecimals.format(transformedAmount);
+    // Returns the value and the decimals = [value, decimals]
+    const [currentValue] = amountCurrency.split('.');
     if (hasNoCurrencySign) {
-      return currencyWithoutDecimals.replace('$', '');
+      return currentValue.replace('$', '');
     }
-    return currencyWithoutDecimals;
+    return currentValue;
   }
   if (hasNoCurrencySign) {
     return amountCurrency.replace('$', '');


### PR DESCRIPTION
# PR Description
- The input did not accept decimals that started with 0 like 190.09
- The input accepted strange characters in the end like 190>
- Fix the test: *Given a user filling the first form correctly and clicking next, then he fill the end date with a past date, should show error validation* because this PR is created on August 1st, so the test is selecting the date 08/30 instead of 07/30 because we were not selecting the change of month